### PR TITLE
Add a readonly config factory

### DIFF
--- a/packages/risio-foundation/src/Application.ts
+++ b/packages/risio-foundation/src/Application.ts
@@ -28,6 +28,13 @@ export class Application {
     public ioc: interfaces.Container
 
     /**
+     * Creates a readonly config object.
+     */
+    public static createConfigObject<TConfig extends object>(config: TConfig): Readonly<TConfig> {
+        return Object.freeze(config)
+    }
+
+    /**
      * Create a new Application
      *
      * @param config

--- a/playground/config/application.ts
+++ b/playground/config/application.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
-import { ApplicationConfig, env } from '@risio/foundation'
+import { Application, ApplicationConfig, env } from '@risio/foundation'
 
-export const applicationConfig: Readonly<ApplicationConfig> = Object.freeze({
+export const applicationConfig = Application.createConfigObject<ApplicationConfig>({
     env: env('ENV', 'development'),
     url: env('APP_URL', 'http://localhost:3000'),
     serverUrl: env('APP_SERVER_URL', 'http://localhost:5000'),

--- a/playground/config/filesystem.ts
+++ b/playground/config/filesystem.ts
@@ -1,9 +1,9 @@
 import * as path from 'path'
 
 import { FilesystemConfig, FilesystemType } from '../../filesystem'
-import { env } from '@risio/foundation'
+import { Application, env } from '@risio/foundation'
 
-export const filesystemConfig: Readonly<FilesystemConfig> = {
+export const filesystemConfig = Application.createConfigObject<FilesystemConfig>({
     adapter: env('FILESYSTEM', 'local'),
 
     adapters: {
@@ -22,4 +22,4 @@ export const filesystemConfig: Readonly<FilesystemConfig> = {
             basePath: 'public'
         }
     }
-},
+})

--- a/playground/config/log.ts
+++ b/playground/config/log.ts
@@ -1,7 +1,7 @@
-import { env } from '@risio/foundation'
+import { Application, env } from '@risio/foundation'
 import { LoggerType, LoggerLevel } from '../../log'
 
-export const logConfig = Object.freeze({
+export const logConfig = Application.createConfigObject({
     adapter: env('LOG', 'console'),
 
     adapters: {

--- a/playground/config/mail.ts
+++ b/playground/config/mail.ts
@@ -1,7 +1,7 @@
 import { MailerType, MailerConfig } from '../../mail'
-import { env } from '@risio/foundation'
+import { Application, env } from '@risio/foundation'
 
-export const mailConfig: MailerConfig = Object.freeze({
+export const mailConfig = Application.createConfigObject<MailerConfig>({
     defaults: {
         fromName: 'John Doe',
         fromEmail: 'noreply@example.com'


### PR DESCRIPTION
This PR will add a factory that creates a readonly frozen config objects.  This creates a more DRY approach to creating config objects in the "application" layer and enforces readonly config objects.